### PR TITLE
only create train and test data when data is provided

### DIFF
--- a/pyautoml/base.py
+++ b/pyautoml/base.py
@@ -27,9 +27,6 @@ class MethodBase(object):
         if data is not None and not use_full_data:
             # Generate train set and test set.
             self.data_properties.train_data, self.data_properties.test_data = split_data(self.data_properties.data, test_split_percentage)
-        else:
-            # Override user input for safety.
-            self.data_properties.use_full_data = False       
 
         if self.data_properties.report is None:
             self.report = None


### PR DESCRIPTION
Only create the test and train dataset when the user passes in 1 dataset and leaves `use_full_data` as false.